### PR TITLE
Refs #1: some performance improvements attempts

### DIFF
--- a/components/elevation-display.vue
+++ b/components/elevation-display.vue
@@ -15,12 +15,16 @@
     gradient?.addColorStop(0.1, "#f43f5e");
     gradient?.addColorStop(0.7, "#22c55e");
     gradient?.addColorStop(1, "#22d3ee");
+    const route =   (props.route.length > 5000) ? props.route.filter((_, idx) => idx % 1000 === 0)
+                  : (props.route.length > 1000) ? props.route.filter((_, idx) => idx % 100 === 0)
+                  : (props.route.length > 200)  ? props.route.filter((_, idx) => idx % 10 === 0)
+                  : props.route;
     props.route.chart = new Chart(canvasRef.value, {
       type: 'line',
       data: {
-        labels: props.route.elevationLabels,
+        labels: route.elevationLabels,
         datasets: [{
-          data: props.route.elevations,
+          data: route.elevations,
           borderWidth: 1,
           tension: 0.3,
           fill: true,


### PR DESCRIPTION
Two attempts at improving performance on longer routes.

DISCLAIMER: I have no JS experience, so this should probably be rewritten in a more idiomatic way.

----

In the first commit, we only get elevation data for 1/10 of the points on longer routes. The points in between are interpolated from the data before/after.

The second commit tries to draw less points in the elevation map for longer routes.
I don't have any measurements, but it feels a bit faster than originally when the routes are over 200-300 km long. (But still way way slower than when the elevation is completely disabled)

----

There's probably a better way to do this and to optimize the elevation map drawing, but I'm out of ideas currently.

@HatAndBread, when you find some time, please try it (and measure performance difference, if any) locally, and let me know if there's any improvement.